### PR TITLE
question to reference course

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,15 +6,14 @@ node {
     stage('Install Dependencies') {
       sh '''#!/bin/bash --login
         . /usr/local/rvm/scripts/rvm
-        echo $USER
-        bundle install
+        bundle install --without development
       '''
     }
 
     stage('Test') {
         sh '''#!/bin/bash --login
           . /usr/local/rvm/scripts/rvm
-          rails test
+          bundle exec rails test
         '''
     }
 
@@ -25,7 +24,7 @@ node {
             rails db:migrate
             rails db:reset
             pkill screen
-            screen -dmSL jds rails server
+            screen -dmSL jds bundle exec rails server
           '''
         }
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-      User.where(username: session[:username]).first
+      User.find_by(username: session[:username])
   end
 
   def require_login

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -4,6 +4,10 @@ class Course < ApplicationRecord
 
   validates :semester, inclusion: { in: %w(SUMMER FALL SPRING) }
 
+  def questions
+    Question.where(course_name: self.name)
+  end
+
   def to_s
     self.name
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,12 +1,9 @@
 class Course < ApplicationRecord
   has_many :registrations
   has_many :users, through: :registrations
+  has_many :questions, foreign_key: 'course_name', primary_key: 'name'
 
   validates :semester, inclusion: { in: %w(SUMMER FALL SPRING) }
-
-  def questions
-    Question.where(course_name: self.name)
-  end
 
   def to_s
     self.name

--- a/db/migrate/20170603151545_add_course_name_to_questions.rb
+++ b/db/migrate/20170603151545_add_course_name_to_questions.rb
@@ -1,0 +1,5 @@
+class AddCourseNameToQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :questions, :course_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531233254) do
+ActiveRecord::Schema.define(version: 20170603151545) do
 
   create_table "answers", force: :cascade do |t|
     t.string "answer"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20170531233254) do
     t.string "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "course_name"
   end
 
   create_table "registrations", force: :cascade do |t|

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -3,11 +3,11 @@
 one:
   year: 1
   semester: MyString
-  name: MyString
+  name: CourseOne
   student_key: MyString
 
 two:
   year: 1
   semester: MyString
-  name: MyString
+  name: CourseTwo
   student_key: MyString

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -2,6 +2,8 @@
 
 one:
   body: MyString
+  course_name: CourseOne
 
 two:
   body: MyString
+  course_name: CourseOne

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 class QuestionTest < ActiveSupport::TestCase
   test "reads questions" do
-    assert_equal 2, Course.where(name: 'CourseOne').first.questions.size()
+    assert_equal 2, Course.find_by(name: 'CourseOne').questions.size()
   end
 end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class QuestionTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "reads questions" do
+    assert_equal 2, Course.where(name: 'CourseOne').first.questions.size()
+  end
 end

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -2,14 +2,14 @@ require "application_system_test_case"
 
 class RegistrationsTest < ApplicationSystemTestCase
   test 'walkthrough for first demo' do
-    assert !User.where(username: 'leahy').first.is_professor
+    assert !User.find_by(username: 'leahy').is_professor
     visit '/users?un=john'
     assert_text 'leahy'
     page.all('a', text: 'Edit')[2].click
     check 'Is professor'
     click_button 'Update User'
     click_on 'Back'
-    assert User.where(username: 'leahy').first.is_professor
+    assert User.find_by(username: 'leahy').is_professor
 
     visit '/courses?un=leahy'
     click_on 'New Course'


### PR DESCRIPTION
Note that I am using a new migration to make the table change. `course_name` is a 'fake' foreign key, I added the method `questions` in course.rb so that you can just do `course.questions` to get a list of the questions that belong to that course. You can see that in the test I made.
+ Migration was generated through CLI. `rails g migration addCoursenameToQuestion coursename:string` or something like that.
+ I changed instances of the `.where .first` to just `find_by` it doesn't do anything different, just shorter. 
+ Fixed jenkinsfile, runs tests and reports back. Doesn't run the browser tests, however.