### PR TITLE
Question join on answer

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -31,7 +31,7 @@ class QuestionsController < ApplicationController
     @question = Question.new(question_params)
 
     respond_to do |format|
-      if @question.save!
+      if @question.save
         format.html { redirect_to @question, notice: 'Question was successfully created.' }
         format.json { render :show, status: :created, location: @question }
       else

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -15,6 +15,7 @@ class QuestionsController < ApplicationController
   # GET /questions/new
   def new
     @question = Question.new
+    5.times { @question.answers.build }
   end
 
   # GET /questions/1/edit
@@ -65,6 +66,7 @@ class QuestionsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_question
       @question = Question.find(params[:id])
+      (5 - @question.answers().size()).times { @question.answers.build }
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -69,6 +69,6 @@ class QuestionsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def question_params
-      params.require(:question).permit(:body, :answers_attributes => [:answer, :id, :_destroy])
+      params.require(:question).permit(:body, :answers_attributes => [:answer, :id, :_destroy, :is_correct])
     end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,11 @@ class QuestionsController < ApplicationController
   # GET /questions
   # GET /questions.json
   def index
-    @questions = Question.all
+    #just ones I have access to
+    @questions = []
+    current_user.courses_as_instructor.each {|c| @questions.push c.questions}
+    @questions.flatten!
+    @questions = Question.all() if current_user.is_admin
   end
 
   # GET /questions/1

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,6 @@ class QuestionsController < ApplicationController
   # GET /questions
   # GET /questions.json
   def index
-    #just ones I have access to
     @questions = []
     current_user.courses_as_instructor.each {|c| @questions.push c.questions}
     @questions.flatten!
@@ -32,7 +31,7 @@ class QuestionsController < ApplicationController
     @question = Question.new(question_params)
 
     respond_to do |format|
-      if @question.save
+      if @question.save!
         format.html { redirect_to @question, notice: 'Question was successfully created.' }
         format.json { render :show, status: :created, location: @question }
       else
@@ -75,6 +74,6 @@ class QuestionsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def question_params
-      params.require(:question).permit(:body, :answers_attributes => [:answer, :id, :_destroy, :is_correct])
+      params.require(:question).permit(:body, :course_name, :answers_attributes => [:answer, :id, :_destroy, :is_correct])
     end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -69,6 +69,6 @@ class QuestionsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def question_params
-      params.require(:question).permit(:body)
+      params.require(:question).permit(:body, :answers_attributes => [:answer, :id, :_destroy])
     end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,3 +1,7 @@
 class Answer < ApplicationRecord
   belongs_to :question
+
+  def to_s
+    answer
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,6 +5,8 @@ class Question < ApplicationRecord
   has_many :question_set_junctions
   has_many :questions, through: :question_set_junctions
 
+  validates :course_name, presence: true
+
   def correct_answers
     answers.find_all { |a| a.is_correct }
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,6 @@
 class Question < ApplicationRecord
   has_many :answers
+  accepts_nested_attributes_for :answers, allow_destroy: true, reject_if: lambda {|a| a['answer'].blank? }
 
   has_many :question_set_junctions
   has_many :questions, through: :question_set_junctions

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,6 @@
 class Question < ApplicationRecord
   has_many :answers
-  accepts_nested_attributes_for :answers, allow_destroy: true, reject_if: lambda {|a| a['answer'].blank? }
+  accepts_nested_attributes_for :answers, allow_destroy: true
 
   has_many :question_set_junctions
   has_many :questions, through: :question_set_junctions

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,4 +4,8 @@ class Question < ApplicationRecord
 
   has_many :question_set_junctions
   has_many :questions, through: :question_set_junctions
+
+  def correct_answers
+    answers.find_all { |a| a.is_correct }
+  end
 end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -16,6 +16,11 @@
     <%= form.text_field :body, id: :question_body %>
   </div>
 
+  <div class="field">
+    <%= form.label :for_course %>
+    <%= form.select(:course_name, Course.all.map { |c| [c.name, c.id] } ) %>
+  </div>
+
   <%= form.fields_for :answers do |answer_form| %>
     <%= answer_form.label :answer %>
     <%= answer_form.text_field :answer %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,3 +1,19 @@
+<script>
+  //http://guides.rubyonrails.org/form_helpers.html#adding-fields-on-the-fly
+  window.onload = function () {
+    $('#myBtn').click(function() {
+      var table = document.getElementById("myTable");
+      var row = table.insertRow(-1);
+      var cell1 = row.insertCell(0);
+      var cell2 = row.insertCell(1);
+      var cell3 = row.insertCell(2);
+      cell1.innerHTML = '<input type="text"></input>';
+      cell2.innerHTML = '<input type="checkbox"></input>';
+      cell3.innerHTML = '<input type="checkbox" disabled></input>';
+    });
+  }
+</script>
+
 <%= form_with(model: question, local: true) do |form| %>
   <% if question.errors.any? %>
     <div id="error_explanation">
@@ -16,7 +32,7 @@
     <%= form.text_field :body, id: :question_body %>
   </div>
 
-  <table>
+  <table id="myTable">
     <tr>
       <th>Answer</th>
       <th>Correct?</th>
@@ -32,7 +48,7 @@
   </table>
 
   <br>
-  <%= button_tag "Add another answer", type: 'button', onclick: '' %>
+  <%= button_tag "Add another answer", id: 'myBtn', type: 'button', onclick: '' %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -16,16 +16,23 @@
     <%= form.text_field :body, id: :question_body %>
   </div>
 
-  <%= form.fields_for :answers do |answer_form| %>
-    <%= answer_form.label :answer %>
-    <%= answer_form.text_field :answer %>
+  <table>
+    <tr>
+      <th>Answer</th>
+      <th>Correct?</th>
+      <th>Delete?</th>
+    </tr>
+    <%= form.fields_for :answers do |answer_form| %>
+      <tr>
+        <td><%= answer_form.text_field :answer %></td>
+        <td><%= answer_form.check_box :is_correct %></td>
+        <td><%= answer_form.check_box :_destroy %></td>
+      </tr>
+    <% end %>
+  </table>
 
-    <%= answer_form.label :is_correct %>
-    <%= answer_form.check_box :is_correct %>
-
-    <%= answer_form.label :delete %>
-    <%= answer_form.check_box :_destroy %>
-  <% end %>
+  <br>
+  <%= button_tag "Add another answer", type: 'button', onclick: '' %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,19 +1,3 @@
-<script>
-  //http://guides.rubyonrails.org/form_helpers.html#adding-fields-on-the-fly
-  window.onload = function () {
-    $('#myBtn').click(function() {
-      var table = document.getElementById("myTable");
-      var row = table.insertRow(-1);
-      var cell1 = row.insertCell(0);
-      var cell2 = row.insertCell(1);
-      var cell3 = row.insertCell(2);
-      cell1.innerHTML = '<input type="text"></input>';
-      cell2.innerHTML = '<input type="checkbox"></input>';
-      cell3.innerHTML = '<input type="checkbox" disabled></input>';
-    });
-  }
-</script>
-
 <%= form_with(model: question, local: true) do |form| %>
   <% if question.errors.any? %>
     <div id="error_explanation">
@@ -32,23 +16,18 @@
     <%= form.text_field :body, id: :question_body %>
   </div>
 
-  <table id="myTable">
-    <tr>
-      <th>Answer</th>
-      <th>Correct?</th>
-      <th>Delete?</th>
-    </tr>
-    <%= form.fields_for :answers do |answer_form| %>
-      <tr>
-        <td><%= answer_form.text_field :answer %></td>
-        <td><%= answer_form.check_box :is_correct %></td>
-        <td><%= answer_form.check_box :_destroy %></td>
-      </tr>
-    <% end %>
-  </table>
+  <%= form.fields_for :answers do |answer_form| %>
+    <%= answer_form.label :answer %>
+    <%= answer_form.text_field :answer %>
+
+    <%= answer_form.label :is_correct %>
+    <%= answer_form.check_box :is_correct %>
+
+    <%= answer_form.label :_destroy %>
+    <%= answer_form.check_box :_destroy %>
+  <% end %>
 
   <br>
-  <%= button_tag "Add another answer", id: 'myBtn', type: 'button', onclick: '' %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -16,6 +16,17 @@
     <%= form.text_field :body, id: :question_body %>
   </div>
 
+  <%= form.fields_for :answers do |answer_form| %>
+    <%= answer_form.label :answer %>
+    <%= answer_form.text_field :answer %>
+
+    <%= answer_form.label :is_correct %>
+    <%= answer_form.check_box :is_correct %>
+
+    <%= answer_form.label :delete %>
+    <%= answer_form.check_box :_destroy %>
+  <% end %>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -3,6 +3,14 @@
 <p>
   <strong>Body:</strong>
   <%= @question.body %>
+  <% @question.answers.each do |a| %>
+    <br>
+    <% if a.is_correct %>
+      <b><%= a %></b>
+    <% else %>
+      <%= a %>
+    <% end %>
+  <% end %>
 </p>
 
 <%= link_to 'Edit', edit_question_path(@question) %> |

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,41 +1,35 @@
-# compilers = Course.create year: 2017, semester: 'SUMMER', name: 'CS 4240', student_key: '3h535jh-443j4n-fdfd'
-# Course.create year: 2015, semester: 'FALL', name: 'CS 3251', student_key: '45j43h5-n32j4-b34jk2'
-# Course.create year: 2014, semester: 'SPRING', name: 'CS 2200', student_key: '4jk23=3n423-kj324'
-#
-#
-# User.create username: 'jtompkins8', fname: 'john', lname: 'tompkins', is_admin: true
-# User.create username: 'rkalhan4', fname: 'robert', lname: 'kalhan', is_admin: false
-# student = User.create username: 'smaer', fname: 'sally', lname: 'maer', is_admin: false
-#
-#
-# Registration.create role: 'STUDENT', user: student, course: Course.where(name: 'CS 4240').first
-# Registration.create role: 'ASSISTANT', user: User.where(username: 'rkalhan4').first, course: Course.where(name: 'CS 4240').first
-#
-#
-# tag = Tag.create tag: 'malloc'
-# Tag.create tag: 'circuit'
-# Tag.create tag: 'register allocation'
-#
-# q1 = Question.create body: 'an implementation of malloc can be found in glibc'
-# q2 = Question.create body: 'register allocation is NP hard'
-# q3 = Question.create body: 'in logisim, you should backup your work periodically'
-#
-# QuestionToTagJunction.create question: q1, tag: tag
-#
-# Answer.create answer: 'true', is_correct: true, question: q1
-# wrong = Answer.create answer: 'false', is_correct: false, question: q1
-#
-# set = QuestionSet.create name: 'my first question set', is_readonly: true
-# QuestionSetJunction.create question: q1, question_set: set
-#
-# lecture = Lecture.create title: 'compilers first lecture', date_of_use: 'June-3-2017', question_set: set
-#
-# CourseToLectureJunction.create course: compilers, lecture: lecture
-#
-# Response.create user: student, lecture: lecture, question: q1, answer: wrong
+compilers = Course.create year: 2017, semester: 'SUMMER', name: 'CS 4240', student_key: '3h535jh-443j4n-fdfd'
+Course.create year: 2015, semester: 'FALL', name: 'CS 3251', student_key: '45j43h5-n32j4-b34jk2'
+Course.create year: 2014, semester: 'SPRING', name: 'CS 2200', student_key: '4jk23=3n423-kj324'
 
 
-#Above commented out for demo seed
-User.create username: 'jtompkins8', fname: 'john', lname: 'tompkins', is_admin: true, is_professor: false
-User.create username: 'rkalhan4', fname: 'robert', lname: 'kalhan', is_admin: false, is_professor: false
-User.create username: 'smaer', fname: 'sally', lname: 'maer', is_admin: false, is_professor: false
+User.create username: 'jtompkins8', fname: 'john', lname: 'tompkins', is_admin: true
+User.create username: 'rkalhan4', fname: 'robert', lname: 'kalhan', is_admin: false
+student = User.create username: 'smaer', fname: 'sally', lname: 'maer', is_admin: false
+
+
+Registration.create role: 'STUDENT', user: student, course: Course.where(name: 'CS 4240').first
+Registration.create role: 'ASSISTANT', user: User.where(username: 'rkalhan4').first, course: Course.where(name: 'CS 4240').first
+
+
+tag = Tag.create tag: 'malloc'
+Tag.create tag: 'circuit'
+Tag.create tag: 'register allocation'
+
+q1 = Question.create body: 'an implementation of malloc can be found in glibc', course_name: 'CS 4240'
+q2 = Question.create body: 'register allocation is NP hard', course_name: 'CS 4240'
+q3 = Question.create body: 'in logisim, you should backup your work periodically', course_name: 'CS 2200'
+
+QuestionToTagJunction.create question: q1, tag: tag
+
+Answer.create answer: 'true', is_correct: true, question: q1
+wrong = Answer.create answer: 'false', is_correct: false, question: q1
+
+set = QuestionSet.create name: 'my first question set', is_readonly: true
+QuestionSetJunction.create question: q1, question_set: set
+
+lecture = Lecture.create title: 'compilers first lecture', date_of_use: 'June-3-2017', question_set: set
+
+CourseToLectureJunction.create course: compilers, lecture: lecture
+
+Response.create user: student, lecture: lecture, question: q1, answer: wrong

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -17,7 +17,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create question" do
     assert_difference('Question.count') do
-      post questions_url, params: { question: { body: @question.body } }
+      post questions_url, params: { question: { body: @question.body, course_name: @question.course_name } }
     end
 
     assert_redirected_to question_url(Question.last)

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -2,10 +2,15 @@
 
 one:
   answer: MyString
-  is_correct: false
+  is_correct: true
   question: one
 
 two:
   answer: MyString
   is_correct: false
   question: two
+
+three:
+  answer: MyString
+  is_correct: false
+  question: one

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  body: MyString
+  body: qone
   course_name: CourseOne
 
 two:
-  body: MyString
+  body: qtwo
   course_name: CourseOne

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -4,4 +4,7 @@ class QuestionTest < ActiveSupport::TestCase
   test "reads questions" do
     assert_equal 2, Course.find_by(name: 'CourseOne').questions.size()
   end
+  test "finds correct answers" do
+    assert_equal 1, Question.find_by(body: 'qone').correct_answers.size()
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -8,6 +8,7 @@ class QuestionsTest < ApplicationSystemTestCase
     find('#question_answers_attributes_0_answer').set 'yes'
     find('#question_answers_attributes_1_answer').set 'no'
     find('#question_answers_attributes_0_is_correct').set(true)
+    select('CourseTwo', :from => 'question[course_name]')
     click_on 'Create Question'
     assert_text 'Question was successfully created.'
     click_on 'Edit'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -1,9 +1,25 @@
 require "application_system_test_case"
 
 class QuestionsTest < ApplicationSystemTestCase
-  # test "visiting the index" do
-  #   visit questions_url
-  #
-  #   assert_selector "h1", text: "Question"
-  # end
+  test "answers get saved with questions" do
+    visit '/questions?un=john'
+    click_on 'New Question'
+    fill_in 'Body', with: 'yesorno'
+    find('#question_answers_attributes_0_answer').set 'yes'
+    find('#question_answers_attributes_1_answer').set 'no'
+    find('#question_answers_attributes_0_is_correct').set(true)
+    click_on 'Create Question'
+    assert_text 'Question was successfully created.'
+    click_on 'Edit'
+    assert_equal 1, Question.find_by(body: 'yesorno').correct_answers.size
+    assert_equal 'yes', Question.find_by(body: 'yesorno').correct_answers.first.answer
+    assert_equal 5, Question.find_by(body: 'yesorno').answers.size
+    find('#question_answers_attributes_0_is_correct').set(false)
+    find('#question_answers_attributes_1_is_correct').set(true)
+    click_on 'Update Question'
+    assert_text 'yesorno'
+    assert_equal 1, Question.find_by(body: 'yesorno').correct_answers.size
+    assert_equal 'no', Question.find_by(body: 'yesorno').correct_answers.first.answer
+    assert_equal 5, Question.find_by(body: 'yesorno').answers.size
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -22,4 +22,11 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal 'no', Question.find_by(body: 'yesorno').correct_answers.first.answer
     assert_equal 5, Question.find_by(body: 'yesorno').answers.size
   end
+
+  test "question not visible by student" do
+    visit '/questions?un=john'
+    assert_text 'qtwo'
+    visit '/questions?un=astudent'
+    assert_no_text 'qtwo'
+  end
 end


### PR DESCRIPTION
This joins the answer model into the question view. When you view a question, you view the corresponding answers. When you add/create a question you also add/create its answers.

The database is designed so that a question can have any number of answers. I started to make this so that the UI lets them add any number of questions they wanted to, and I found it was a bit of work. So for now this just defaults to five answers. We can always add that feature on later, no need to get stuck now on something so small. 

Right now the form is really ugly since the inputs are vertically stacked on each other, one by one. I'll play around with bootstrap and see if I can make it  better. 