### PR TITLE
rename assistant to instructor

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -39,7 +39,7 @@ class CoursesController < ApplicationController
     respond_to do |format|
       if @course.save
         if current_user.is_professor
-          Registration.create! user: current_user, course: @course, role: 'ASSISTANT'
+          Registration.create! user: current_user, course: @course, role: 'INSTRUCTOR'
         end
         format.html { redirect_to @course, notice: 'Course was successfully created.' }
         format.json { render :show, status: :created, location: @course }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -2,5 +2,5 @@ class Registration < ApplicationRecord
   belongs_to :user
   belongs_to :course
 
-  validates :role, inclusion: { in: %w(STUDENT ASSISTANT) }
+  validates :role, inclusion: { in: %w(STUDENT INSTRUCTOR) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :responses
 
   def courses_as_instructor
-    Registration.where(user: self, role: 'ASSISTANT').map { |r| r.course }
+    Registration.where(user: self, role: 'INSTRUCTOR').map { |r| r.course }
   end
 
   def to_s

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -15,7 +15,7 @@
 
   <div class="field">
     <%= form.label :role %>
-    <%= form.select(:role, [['ASSISTANT', 'ASSISTANT'], ['STUDENT', 'STUDENT']]) %>
+    <%= form.select(:role, [['INSTRUCTOR', 'INSTRUCTOR'], ['STUDENT', 'STUDENT']]) %>
   </div>
 
   <div class="actions">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,8 +11,8 @@ prof = User.create username: 'testprof', fname: 'test', lname: 'prof', is_admin:
 
 Registration.create role: 'STUDENT', user: student, course: Course.where(name: 'CS 4240').first
 Registration.create role: 'STUDENT', user: student2, course: Course.where(name: 'CS 4240').first
-Registration.create role: 'ASSISTANT', user: User.where(username: 'rkalhan4').first, course: Course.where(name: 'CS 4240').first
-Registration.create role: 'ASSISTANT', user: prof, course: Course.where(name: "CS 2200").first
+Registration.create role: 'INSTRUCTOR', user: User.where(username: 'rkalhan4').first, course: Course.where(name: 'CS 4240').first
+Registration.create role: 'INSTRUCTOR', user: prof, course: Course.where(name: "CS 2200").first
 
 tag = Tag.create tag: 'malloc'
 tag2 = Tag.create tag: 'circuit'

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -37,7 +37,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update registration" do
     controller.session[:username] = 'comeon'
-    patch registration_url(@registration), params: { un: 'leahy', registration: {role: 'ASSISTANT'} }
+    patch registration_url(@registration), params: { un: 'leahy', registration: {role: 'INSTRUCTOR'} }
     assert_redirected_to registration_url(@registration)
   end
 

--- a/test/fixtures/registrations.yml
+++ b/test/fixtures/registrations.yml
@@ -6,6 +6,6 @@ one:
   course: one
 
 two:
-  role: ASSISTANT
+  role: INSTRUCTOR
   user: two
   course: one

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -23,7 +23,7 @@ class RegistrationsTest < ApplicationSystemTestCase
 
     click_on 'registrations'
     click_on 'New Registration'
-    fill_in 'Role', with: 'ASSISTANT'
+    fill_in 'Role', with: 'INSTRUCTOR'
     select('jonathan', :from => 'registration[user_id]')
     select('CS2110', :from => 'registration[course_id]')
     click_on 'Create Registration'


### PR DESCRIPTION
This was really bothering me. Assistant is a bad word since a professor would be registered under this role as well as the TA. 

Used this command to make the changes:
`find . -type f -exec sed -i 's/ASSISTANT/INSTRUCTOR/g' {} \;`